### PR TITLE
Wrote Feature that allows us to switch the networkpath

### DIFF
--- a/aimsunBridge.py
+++ b/aimsunBridge.py
@@ -147,8 +147,9 @@ class AimSunBridge:
             return "error reading"
         
     def executeAimsunScript(self, moduleDict, console, model):
-        # This function is responsible for calling the modules of interest. It passes 
-        # in the console and model and uses the importlib library to import and run the module
+        """This function is responsible for calling the modules of interest. It passes 
+        in the console and model and uses the importlib library to import and run the module
+        """
         spec = importlib.util.spec_from_file_location('tool', moduleDict['toolPath'])
         moduleToRun = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(moduleToRun)
@@ -158,6 +159,9 @@ class AimSunBridge:
         func(moduleDict['parameters'], model, console)
 
     def executeModule(self, console, model):
+        """Function which executes the modules by extracting the tool and 
+        its json parameters
+        """
         macroName = None
         parameterString = None
         # run the module here
@@ -222,7 +226,6 @@ class AimSunBridge:
             return model
         except Exception as e:
             self.sendRuntimeError(str(e))
-
 
     def run(self):
         # Function to run the pipe

--- a/aimsunBridge.py
+++ b/aimsunBridge.py
@@ -192,28 +192,34 @@ class AimSunBridge:
     def checkToolExists(self):
         return True
 
-    def loadModel(self):
-        """Function to load the model"""
-        # open the console and create a model. This is passed around inside this script and also
-        # to external modules
-        console = ANGConsole([])
+    def loadModel(self, console):
+        """Function to load the model
+        open the console and create a model. This is passed around inside this script and also
+        to external modules
+        """
         if console.open(self.NetworkPath):
             model = console.getModel()
             print("Network opened successfully")
         else:
             console.getLog().addError("Cannot load the network")
             print("Cannot load the network")
-        return console, model
+        return model
 
 
-    def switchModel(self):
+    def switchModel(self, console):
+        """function to open a new model based on a new network. The network filepath
+        is passed from the bridge
+        """
         print ("switching model")
         try:
             # extract the name of the tool along with the parameters and pass it to the function
             self.NetworkPath = self.readString()
-            print (self.NetworkPath)
-            console, model = self.loadModel()
-            return console, model
+            print ('switched path files ', self.NetworkPath)
+
+            model = self.loadModel(console)
+            # send to the pipe that we ran the message successfully
+            self.sendSuccess()
+            return model
         except Exception as e:
             self.sendRuntimeError(str(e))
 
@@ -226,7 +232,8 @@ class AimSunBridge:
 
         # open the console and create a model. This is passed around inside this script and also
         # the modules of interest.
-        console, model = self.loadModel()
+        console = ANGConsole([])
+        model = self.loadModel(console)  
 
         # send the start signal the first signal to C# server side
         self.sendSignal(self.SignalStart)
@@ -243,10 +250,7 @@ class AimSunBridge:
                 elif input == self.SwitchNetworkPath:
                     #we need to switch the network path and open console and get
                     #model to that network
-                    self.switchModel()
-                    # send to the pipe that we ran the message successfully
-                    self.sendSuccess()
-                    self.sendSignal(self.SignalStart)
+                    model = self.switchModel(console)
                 else:
                     # If we do not understand what XTMF is saying quietly die
                     exit = True

--- a/aimsunBridge.py
+++ b/aimsunBridge.py
@@ -72,7 +72,7 @@ class AimSunBridge:
         """Signal to XTMF saying that the current tool is not compatible with XTMF2"""
         self.SignalIncompatibleTool = 15
         """A signal to switch and open the console on a new path"""
-        self.SwitchNetworkPath = 16
+        self.SignalSwitchNetworkPath = 16
         
         # open the named pipe
         pipeName = sys.argv[1] 
@@ -250,7 +250,7 @@ class AimSunBridge:
                     self.executeModule(console, model)
                 elif input == self.SignalCheckToolExists:
                     self.checkToolExists()
-                elif input == self.SwitchNetworkPath:
+                elif input == self.SignalSwitchNetworkPath:
                     #we need to switch the network path and open console and get
                     #model to that network
                     model = self.switchModel(console)

--- a/src/TMG.Aimsun/AimsunController.cs
+++ b/src/TMG.Aimsun/AimsunController.cs
@@ -129,21 +129,6 @@ namespace TMG.Aimsun
                 startInfo.WorkingDirectory = aimsunPath;
                 aimsun.StartInfo = startInfo;
                 aimsun.Start();
-                // This Code is commented out for debugging purposes if one wishes to debug using two visual studio
-                // instances. This would be useful if you need to debug the bridge itself. Note your project settings 
-                // will need to be readjusted.
-                //if (launchAimsun == true)
-                //{
-                //    //get location of assembly where modellercontroller is
-                //    var codeBase = typeof(ModellerController).GetTypeInfo().Assembly.Location;
-                //    string argumentString = "-script " + AddQuotes(Path.Combine(Path.GetDirectoryName(codeBase), "AimsunBridge.py"))
-                //                            + " " + AddQuotes(pipeName) + " " + AddQuotes(projectFile);
-                //    var aimsun = new Process();
-                //    var startInfo = new ProcessStartInfo(Path.Combine(aimsunPath, "aconsole.exe"), argumentString);
-                //    startInfo.WorkingDirectory = aimsunPath;
-                //    aimsun.StartInfo = startInfo;
-                //    aimsun.Start();
-                //}
                 _aimsunPipe.WaitForConnection();
                 var reader = new BinaryReader(_aimsunPipe, System.Text.Encoding.Unicode, true);
                 reader.ReadInt32();    

--- a/src/TMG.Aimsun/AimsunController.cs
+++ b/src/TMG.Aimsun/AimsunController.cs
@@ -221,7 +221,7 @@ namespace TMG.Aimsun
                 throw new XTMFRuntimeException(caller, "Aimsun Bridge was invoked even though it has already been disposed.");
             }
         }
-        public bool SwitchModel(IModule caller, string macroName, string jsonParameters)
+        public bool SwitchModel(IModule caller, string networkPath, string jsonParameters)
         {
             lock (this)
             {
@@ -232,17 +232,8 @@ namespace TMG.Aimsun
                     var writer = new BinaryWriter(_aimsunPipe, Encoding.Unicode, true);
                     {
                         writer.Write(SignalSwitchNetworkPath);
-                        writer.Write(macroName.Length);
-                        writer.Write(macroName.ToCharArray());
-                        if (jsonParameters == null)
-                        {
-                            writer.Write((int)0);
-                        }
-                        else
-                        {
-                            writer.Write(jsonParameters.Length);
-                            writer.Write(jsonParameters.ToCharArray());
-                        }
+                        writer.Write(networkPath.Length);
+                        writer.Write(networkPath.ToCharArray());
                         writer.Flush();
                     }
                 }

--- a/src/TMG.Aimsun/AimsunController.cs
+++ b/src/TMG.Aimsun/AimsunController.cs
@@ -109,7 +109,7 @@ namespace TMG.Aimsun
             return String.Concat("\"", fileName, "\"");
         }
 
-        public ModellerController(IModule module, string projectFile, string pipeName, string aimsunPath, bool launchAimsun=true)
+        public ModellerController(IModule module, string projectFile, string pipeName, string aimsunPath)
         {
             //check if file path or ang file exists
             if (!projectFile.EndsWith(".ang") | !File.Exists(projectFile))
@@ -208,8 +208,8 @@ namespace TMG.Aimsun
         }
 
         /// <summary>
-        /// Method outputting a bool that alllows us to pass in a NetworkPath to
-        /// change the network we wish to analyze. Useful for running our unittests
+        /// Method outputting a bool that allows us to pass in a NetworkPath to
+        /// change the network we wish to analyze. Useful for running our unit tests
         /// </summary>
         public bool SwitchModel(IModule caller, string networkPath)
         {

--- a/src/TMG.Aimsun/AimsunController.cs
+++ b/src/TMG.Aimsun/AimsunController.cs
@@ -206,6 +206,11 @@ namespace TMG.Aimsun
                 throw new XTMFRuntimeException(caller, "Aimsun Bridge was invoked even though it has already been disposed.");
             }
         }
+
+        /// <summary>
+        /// Method outputting a bool that alllows us to pass in a NetworkPath to
+        /// change the network we wish to analyze. Useful for running our unittests
+        /// </summary>
         public bool SwitchModel(IModule caller, string networkPath)
         {
             lock (this)

--- a/src/TMG.Aimsun/AimsunController.cs
+++ b/src/TMG.Aimsun/AimsunController.cs
@@ -221,7 +221,7 @@ namespace TMG.Aimsun
                 throw new XTMFRuntimeException(caller, "Aimsun Bridge was invoked even though it has already been disposed.");
             }
         }
-        public bool SwitchModel(IModule caller, string networkPath, string jsonParameters)
+        public bool SwitchModel(IModule caller, string networkPath)
         {
             lock (this)
             {

--- a/src/TMGToolbox/inputOutput/importNetwork.py
+++ b/src/TMGToolbox/inputOutput/importNetwork.py
@@ -512,7 +512,6 @@ def runAimsun(parameters, model, console):
     _execute(networkDirectory, outputNetworkFile, model, console)
 
 # Main script to complete the full network import
-#def _execute(blankNetwork, networkDirectory, outputNetworkFile, inputModel, console):
 def _execute(networkDirectory, outputNetworkFile, inputModel, console):
     print ('main ran')
     overallStartTime = time.perf_counter()

--- a/src/TMGToolbox/inputOutput/importNetwork.py
+++ b/src/TMGToolbox/inputOutput/importNetwork.py
@@ -507,13 +507,13 @@ def loadModel(filepath, console):
 def runAimsun(parameters, model, console):
     # A general function called in all python modules called by bridge. Responsible
     # for extracting data and running appropriate functions.
-    blankNetwork = parameters['BlankNetwork']
     outputNetworkFile = parameters["OutputNetworkFile"]
     networkDirectory = parameters["ModelDirectory"]
-    _execute(blankNetwork, networkDirectory, outputNetworkFile, model, console)
+    _execute(networkDirectory, outputNetworkFile, model, console)
 
 # Main script to complete the full network import
-def _execute(blankNetwork, networkDirectory, outputNetworkFile, inputModel, console):
+#def _execute(blankNetwork, networkDirectory, outputNetworkFile, inputModel, console):
+def _execute(networkDirectory, outputNetworkFile, inputModel, console):
     print ('main ran')
     overallStartTime = time.perf_counter()
     global model

--- a/src/TMGToolbox/inputOutput/importNetwork.py
+++ b/src/TMGToolbox/inputOutput/importNetwork.py
@@ -509,7 +509,7 @@ def runAimsun(parameters, model, console):
     # for extracting data and running appropriate functions.
     blankNetwork = parameters['BlankNetwork']
     outputNetworkFile = parameters["OutputNetworkFile"]
-    networkDirectory = parameters["NetworkDirectory"]
+    networkDirectory = parameters["ModelDirectory"]
     _execute(blankNetwork, networkDirectory, outputNetworkFile, model, console)
 
 # Main script to complete the full network import

--- a/test/TMG.Aimsun.Tests/Helper.cs
+++ b/test/TMG.Aimsun.Tests/Helper.cs
@@ -34,11 +34,11 @@ namespace TMG.Aimsun.Tests
     /// </summary>
     class TestConfiguration
     {
-        public string BlankNetwork { get; set; }
-        public string OutputNetworkFile { get; set; }
+        public string Network { get; set; }
+        public string NetworkFolder { get; set; }
         public string ModelDirectory { get; set; }
         public string AimsunPath { get; set; }
-        public string ModulePath { get; set; }     
+        public string ModulePath { get; set; }
     }
 
     /// <summary>
@@ -76,7 +76,8 @@ namespace TMG.Aimsun.Tests
                     //check if debugger is attached if it is used a random name otherwise use the default name DEBUGaimsum
                     bool debuggerAttached = Debugger.IsAttached;
                     string pipeName = debuggerAttached ? "DEBUGaimsun" : Guid.NewGuid().ToString();
-                    Modeller = new ModellerController(null, TestConfiguration.BlankNetwork, pipeName, TestConfiguration.AimsunPath, !debuggerAttached);
+                    string Network = Path.Combine(TestConfiguration.NetworkFolder, "aimsunFiles", TestConfiguration.Network);
+                    Modeller = new ModellerController(null, Network, pipeName, TestConfiguration.AimsunPath, !debuggerAttached);
                 }
             }
         }

--- a/test/TMG.Aimsun.Tests/Helper.cs
+++ b/test/TMG.Aimsun.Tests/Helper.cs
@@ -34,13 +34,21 @@ namespace TMG.Aimsun.Tests
     /// </summary>
     class TestConfiguration
     {
-        //The name of the parent network we wish to run
+        ///<summary>
+        ///The name of the parent network we wish to run
+        ///</summary>
         public string Network { get; set; }
-        //The parent directory where both the unzipped network and the aimsun files reside and are located
+        ///<summary>
+        ///The parent folder where both the unzipped network and the aimsun files reside and are located
+        ///</summary>
         public string NetworkFolder { get; set; }
-        //Path to where Aimsun is installed and located 
+        ///<summary>
+        ///Path to where Aimsun is installed and located 
+        ///</summary>
         public string AimsunPath { get; set; }
-        //base root folder to where aimsun python modules are saved
+        ///<summary>
+        ///Base root folder to where aimsun python Aimsun modules are located
+        ///</summary>
         public string ModulePath { get; set; }
     }
 

--- a/test/TMG.Aimsun.Tests/Helper.cs
+++ b/test/TMG.Aimsun.Tests/Helper.cs
@@ -34,10 +34,13 @@ namespace TMG.Aimsun.Tests
     /// </summary>
     class TestConfiguration
     {
+        //The name of the parent network we wish to run
         public string Network { get; set; }
+        //The parent directory where both the unzipped network and the aimsun files reside and are located
         public string NetworkFolder { get; set; }
-        public string ModelDirectory { get; set; }
+        //Path to where Aimsun is installed and located 
         public string AimsunPath { get; set; }
+        //base root folder to where aimsun python modules are saved
         public string ModulePath { get; set; }
     }
 

--- a/test/TMG.Aimsun.Tests/Helper.cs
+++ b/test/TMG.Aimsun.Tests/Helper.cs
@@ -88,7 +88,7 @@ namespace TMG.Aimsun.Tests
                     bool debuggerAttached = Debugger.IsAttached;
                     string pipeName = debuggerAttached ? "DEBUGaimsun" : Guid.NewGuid().ToString();
                     string Network = Path.Combine(TestConfiguration.NetworkFolder, "aimsunFiles", TestConfiguration.Network);
-                    Modeller = new ModellerController(null, Network, pipeName, TestConfiguration.AimsunPath, !debuggerAttached);
+                    Modeller = new ModellerController(null, Network, pipeName, TestConfiguration.AimsunPath);
                 }
             }
         }

--- a/test/TMG.Aimsun.Tests/Helper.cs
+++ b/test/TMG.Aimsun.Tests/Helper.cs
@@ -36,7 +36,7 @@ namespace TMG.Aimsun.Tests
     {
         public string BlankNetwork { get; set; }
         public string OutputNetworkFile { get; set; }
-        public string NetworkDirectory { get; set; }
+        public string ModelDirectory { get; set; }
         public string AimsunPath { get; set; }
         public string ModulePath { get; set; }     
     }

--- a/test/TMG.Aimsun.Tests/TestAimsunBridge.cs
+++ b/test/TMG.Aimsun.Tests/TestAimsunBridge.cs
@@ -48,5 +48,18 @@ namespace TMG.Aimsun.Tests
             string modulePath = Path.Combine(Helper.TestConfiguration.ModulePath, "inputOutput\\importNetwork.py");
             Helper.Modeller.Run(null, modulePath, json);
         }
+
+        [TestMethod]
+        public void SwitchNetworkPath()
+        {
+            //we're testing we can switch the network path and then run the newtwok
+            string bn = Helper.TestConfiguration.BlankNetwork;
+            Helper.Modeller.SwitchModel(null, bn, null);
+            //now we run the network
+            string json = JsonConvert.SerializeObject(Helper.TestConfiguration);
+            //function that can take string or whatever and generate json and combine two json together
+            string modulePath = Path.Combine(Helper.TestConfiguration.ModulePath, "inputOutput\\importNetwork.py");
+            Helper.Modeller.Run(null, modulePath, json);
+        }
     }
 }

--- a/test/TMG.Aimsun.Tests/TestAimsunBridge.cs
+++ b/test/TMG.Aimsun.Tests/TestAimsunBridge.cs
@@ -36,7 +36,7 @@ namespace TMG.Aimsun.Tests
         [Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyInitialize]
         public static void InitTest(TestContext _)
         {
-            //initalize the Aimsun module
+            //initialize the Aimsun module
             Helper.InitializeAimsun();
         }
 

--- a/test/TMG.Aimsun.Tests/TestAimsunBridge.cs
+++ b/test/TMG.Aimsun.Tests/TestAimsunBridge.cs
@@ -43,36 +43,18 @@ namespace TMG.Aimsun.Tests
         [TestMethod]
         public void ConstructAimsunBridge()
         {
-            string json = JsonConvert.SerializeObject(Helper.TestConfiguration);
             //function that can take string or whatever and generate json and combine two json together
             string modulePath = Path.Combine(Helper.TestConfiguration.ModulePath, "inputOutput\\importNetwork.py");
-            var myData2 = new
+            ///<summary>
+            ///the json parameters we will pass to the bridge via the pipe that are the inputs to the python
+            ///modules
+            ///</summary>
+            string jsonParameters = JsonConvert.SerializeObject(new
             {
                 OutputNetworkFile = Path.Combine(Helper.TestConfiguration.NetworkFolder, "aimsunFiles\\FrabitztownNetwork.ang"),
                 ModelDirectory = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\Frabitztown")
-            };
-            string jsonData = JsonConvert.SerializeObject(myData2);
-            Helper.Modeller.Run(null, modulePath, jsonData);
-        }
-
-        [TestMethod]
-        public void SwitchNetworkPath()
-        {
-            //we're testing we can switch the network path and then run the network
-            string bn = Path.Combine(Helper.TestConfiguration.NetworkFolder, "aimsunFiles\\blankNetworkWithVdfs.ang");
-            //Helper.TestConfiguration.Network;
-            Helper.Modeller.SwitchModel(null, bn);
-            //now we run the network
-            string json = JsonConvert.SerializeObject(Helper.TestConfiguration);
-            //function that can take string or whatever and generate json and combine two json together
-            string modulePath = Path.Combine(Helper.TestConfiguration.ModulePath, "inputOutput\\importNetwork.py");
-            var myData2 = new
-            {
-                OutputNetworkFile = Path.Combine(Helper.TestConfiguration.NetworkFolder, "aimsunFiles\\FrabitztownNetwork.ang"),
-                ModelDirectory = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\Frabitztown")
-            };
-            string jsonData = JsonConvert.SerializeObject(myData2);
-            Helper.Modeller.Run(null, modulePath, jsonData);
+            });
+            Helper.Modeller.Run(null, modulePath, jsonParameters);
         }
     }
 }

--- a/test/TMG.Aimsun.Tests/TestAimsunBridge.cs
+++ b/test/TMG.Aimsun.Tests/TestAimsunBridge.cs
@@ -46,20 +46,33 @@ namespace TMG.Aimsun.Tests
             string json = JsonConvert.SerializeObject(Helper.TestConfiguration);
             //function that can take string or whatever and generate json and combine two json together
             string modulePath = Path.Combine(Helper.TestConfiguration.ModulePath, "inputOutput\\importNetwork.py");
-            Helper.Modeller.Run(null, modulePath, json);
+            var myData2 = new
+            {
+                OutputNetworkFile = Path.Combine(Helper.TestConfiguration.NetworkFolder, "aimsunFiles\\FrabitztownNetwork.ang"),
+                ModelDirectory = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\Frabitztown")
+            };
+            string jsonData = JsonConvert.SerializeObject(myData2);
+            Helper.Modeller.Run(null, modulePath, jsonData);
         }
 
         [TestMethod]
         public void SwitchNetworkPath()
         {
-            //we're testing we can switch the network path and then run the newtwok
-            string bn = Helper.TestConfiguration.BlankNetwork;
-            Helper.Modeller.SwitchModel(null, bn, null);
+            //we're testing we can switch the network path and then run the network
+            string bn = Path.Combine(Helper.TestConfiguration.NetworkFolder, "aimsunFiles\\blankNetworkWithVdfs.ang");
+            //Helper.TestConfiguration.Network;
+            Helper.Modeller.SwitchModel(null, bn);
             //now we run the network
             string json = JsonConvert.SerializeObject(Helper.TestConfiguration);
             //function that can take string or whatever and generate json and combine two json together
             string modulePath = Path.Combine(Helper.TestConfiguration.ModulePath, "inputOutput\\importNetwork.py");
-            Helper.Modeller.Run(null, modulePath, json);
+            var myData2 = new
+            {
+                OutputNetworkFile = Path.Combine(Helper.TestConfiguration.NetworkFolder, "aimsunFiles\\FrabitztownNetwork.ang"),
+                ModelDirectory = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\Frabitztown")
+            };
+            string jsonData = JsonConvert.SerializeObject(myData2);
+            Helper.Modeller.Run(null, modulePath, jsonData);
         }
     }
 }


### PR DESCRIPTION
We can open a new console and model on defined pre-existing network file. The python side does extract the path and opens a new console. Only issue is that resulting calls to run a second time. The pipe is open though.
Also moved the opening of the console and model into its own function called loadModel making it more flexible and robust.
Some grammar typos will need to be fixed as well