### PR TITLE
Added ImportNetwork to XTMF GUI

### DIFF
--- a/src/TMG.Aimsun/AimsunTool.cs
+++ b/src/TMG.Aimsun/AimsunTool.cs
@@ -22,8 +22,7 @@ using XTMF;
 
 namespace TMG.Aimsun
 {
-    [ModuleInformation(Description = @"The aimsun tool to run it takes an aimsun and a list of all the arguments you 
-    need to run it ")]
+    [ModuleInformation(Description = "The aimsun tool to run it takes an aimsun and a list of all the arguments you need to run it ")]
     public class AimSunTool : IAimsunTool
     {
         [RunParameter("Tool Arguments", "", "The arguments of the Aimsun tool you want to run")]

--- a/src/TMG.Aimsun/InputOutput/ImportNetwork.cs
+++ b/src/TMG.Aimsun/InputOutput/ImportNetwork.cs
@@ -56,7 +56,7 @@ namespace TMG.Aimsun.InputOutput
         {
             if (aimsunController == null)
             {
-                throw new XTMFRuntimeException(this, "this broke for osme reason ");
+                throw new XTMFRuntimeException(this, "this broke for some reason ");
             }
             return aimsunController.Run(this, Path.Combine(ToolboxDirectory, ToolName), 
                 JsonParameterBuilder.BuildParameters(writer => 

--- a/src/TMGToolbox/inputOutput/importPedestrians.py
+++ b/src/TMGToolbox/inputOutput/importPedestrians.py
@@ -196,18 +196,16 @@ def run_xtmf(parameters, model, console):
     A general function called in all python modules called by bridge. Responsible
     for extracting data and running appropriate functions.
     """
-    outputNetworkFile = parameters["OutputNetworkFile"]
     networkDirectory = parameters["ModelDirectory"]
-    _execute(networkDirectory, outputNetworkFile, model, console)
+    _execute(networkDirectory, model, console)
 
-def _execute(networkDirectory, outputNetworkFile, inputModel, console):
+def _execute(networkDirectory, inputModel, console):
     """ 
     Main execute function to run the simulation 
     """
     overallStartTime = time.perf_counter()
     loadModelStartTime = time.perf_counter()
-    networkDir = networkDirectory
-    outputNetworkFilename = outputNetworkFile
+
     model = inputModel
     catalog = model.getCatalog()
     geomodel = model.getGeoModel()
@@ -253,7 +251,7 @@ def runFromConsole(inputArgs):
     # generate a model of the input network
     model, catalog, geomodel = loadModel(Network, console)
     #run the _execute function
-    _execute(networkDirectory, outputNetworkFile, model, console)
+    _execute(networkDirectory, model, console)
     saveNetwork(console, model, outputNetworkFile)
 
 if __name__ == "__main__":

--- a/test/TMG.Aimsun.Tests/TestModuleImportPedestrians.cs
+++ b/test/TMG.Aimsun.Tests/TestModuleImportPedestrians.cs
@@ -35,15 +35,13 @@ namespace TMG.Aimsun.Tests
             string modulePath = Path.Combine(Helper.TestConfiguration.ModulePath, "inputOutput\\importPedestrians.py");
             string jsonParameters = JsonConvert.SerializeObject(new
             {
-                OutputNetworkFile = Path.Combine(Helper.TestConfiguration.NetworkFolder, "aimsunFiles\\output\\FrabitztownNetworkWithPedestrians.ang"),
-                ModelDirectory = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\Frabitztown"),
-                ToolboxInputOutputPath = Path.Combine(Helper.TestConfiguration.NetworkFolder, "src\\TMGToolbox\\inputOutput")
+                ModelDirectory = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\Frabitztown")
             });
             Helper.Modeller.Run(null, modulePath, jsonParameters);
         }
 
         [TestMethod]
-        public void TestNetworkSave()
+        public void TestSaveImportPedestrians()
         {
             //change the network
             string newNetwork = Path.Combine(Helper.TestConfiguration.NetworkFolder, "aimsunFiles\\FrabitztownNetworkWithTransit.ang");
@@ -51,11 +49,10 @@ namespace TMG.Aimsun.Tests
             string modulePath = Path.Combine(Helper.TestConfiguration.ModulePath, "inputOutput\\importPedestrians.py");
             string jsonParameters = JsonConvert.SerializeObject(new
             {
-                OutputNetworkFile = Path.Combine(Helper.TestConfiguration.NetworkFolder, "aimsunFiles\\output\\FrabitztownNetworkWithPedestrians.ang"),
-                ModelDirectory = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\Frabitztown"),
-                ToolboxInputOutputPath = Path.Combine(Helper.TestConfiguration.NetworkFolder, "src\\TMGToolbox\\inputOutput")
+                ModelDirectory = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\Frabitztown")
             });
             Helper.Modeller.Run(null, modulePath, jsonParameters);
+
             //build an output file location of where to save the file
             string outputPath = Path.Combine(Helper.TestConfiguration.NetworkFolder, "aimsunFiles\\test3\\FrabitztownNetworkWithPedestrians.ang");
             Helper.Modeller.SaveNetworkModel(null, outputPath);


### PR DESCRIPTION
removed dead code in importpedestrian.py and testimportpedestrian. Specifically the output network file
removed the extra space in aimsuntools
fixed the spelling error mistake in xtmfruntimeexception in importnetwork.cs