### PR TITLE
refactored ImportTransitSchedule

### DIFF
--- a/src/TMG.Aimsun/InputOutput/ImportTransitSchedule.cs
+++ b/src/TMG.Aimsun/InputOutput/ImportTransitSchedule.cs
@@ -29,17 +29,14 @@ namespace TMG.Aimsun.InputOutput
     {
         private const string ToolName = "InputOutput/importTransitSchedule.py";
 
-        [SubModelInformation(Required = true, Description = "The directory of the network")]
-        public FileLocation NetworkDirectory;
+        [SubModelInformation(Required = true, Description = "The path to where the network package file (.nwp) is located")]
+        public FileLocation NetworkPackageFile;
 
         [SubModelInformation(Required = true, Description = "The directory of the Aimsun toolbox")]
         public FileLocation ToolboxDirectory;
 
-        [SubModelInformation(Required = true, Description = "The file location of the service table csv file")]
+        [SubModelInformation(Required = true, Description = "The path where the service table (.csv) file is located")]
         public FileLocation ServiceTableCSV;
-
-        [SubModelInformation(Required = true, Description = "The file location of the transit file")]
-        public FileLocation TransitFile;
 
         public float Progress
         {
@@ -67,12 +64,10 @@ namespace TMG.Aimsun.InputOutput
             return aimsunController.Run(this, Path.Combine(ToolboxDirectory, ToolName),
                 JsonParameterBuilder.BuildParameters(writer =>
                 {
-                    writer.WritePropertyName("ModelDirectory");
-                    writer.WriteValue(NetworkDirectory.GetFilePath());
+                    writer.WritePropertyName("NetworkPackageFile");
+                    writer.WriteValue(NetworkPackageFile.GetFilePath());
                     writer.WritePropertyName("ServiceTableCSV");
                     writer.WriteValue(ServiceTableCSV.GetFilePath());
-                    writer.WritePropertyName("TransitFile");
-                    writer.WriteValue(TransitFile.GetFilePath());
                 }));
         }
     }

--- a/src/TMGToolbox/inputOutput/common/common.py
+++ b/src/TMGToolbox/inputOutput/common/common.py
@@ -116,7 +116,7 @@ def parseArguments(argv):
     outputNetworkFilename = argv[3]
     return inputModel, networkDirectory, outputNetworkFilename
 
-def readTransitFile(networkZipFileObject, filename):
+def getTransitNodesStopsAndLinesFromNWP(networkZipFileObject):
     """
     Function to read the transit.221 file and return the 
     relevant information for the import to Aimsun
@@ -130,7 +130,7 @@ def readTransitFile(networkZipFileObject, filename):
     lineNodes = []
     lineStops = []
 
-    lines = read_datafile(networkZipFileObject, filename)
+    lines = read_datafile(networkZipFileObject, "transit.221")
     for line in lines:
         if line[0] == 'c' or line[0] == 't':
             if currentlyReadingLine != None:

--- a/src/TMGToolbox/inputOutput/importTransitNetwork.py
+++ b/src/TMGToolbox/inputOutput/importTransitNetwork.py
@@ -139,59 +139,11 @@ def importTransitVehicles(networkZipFileObject, filename, catalog, model):
         folder.append(veh)
     return vehicles
 
-# Function to read the transit.221 file and return the relevant information for the import to Aimsun
-def readTransitFile(networkZipFileObject, filename):
-    nodes = []
-    stops = []
-    lines = []
-    transitLines = []
-    currentlyReadingLine = None
-    lineInfo = None
-    lineNodes = []
-    lineStops = []
-
-    lines = common.read_datafile(networkZipFileObject, filename)
-    for line in lines:
-        if line[0] == 'c' or line[0] == 't':
-            if currentlyReadingLine != None:
-                nodes.append(lineNodes)
-                stops.append(lineStops)
-                transitLines.append(lineInfo)
-            # Clear all the currently reading item
-            currentlyReadingLine = None
-            lineInfo = None
-            lineNodes = []
-            lineStops = []
-        elif line[0] == 'a':
-            # if there is a line that was being read add it
-            if currentlyReadingLine != None:
-                nodes.append(lineNodes)
-                stops.append(lineStops)
-                transitLines.append(lineInfo)
-            # set the new line details
-            lineInfo = shlex.split(line[1:])
-            currentlyReadingLine = lineInfo[0]
-            lineNodes = []
-            lineStops = []
-        # if not comment or heading read into current transit line
-        else:
-            pathDetails = shlex.split(line)
-            # TODO add error if path=yes
-            if pathDetails[0] != 'path=no':
-                lineNodes.append(pathDetails[0])
-                dwt = float(pathDetails[1][5:])
-                lineStops.append(dwt)
-    # if get to the end of the file add the last line that was read
-    if currentlyReadingLine != None:
-        nodes.append(lineNodes)
-        stops.append(lineStops)
-        transitLines.append(lineInfo)
-
-    return nodes, stops, transitLines
-
-# Function to create the bus stop objects in the Aimsun network
-# repeatNumber is the number of times that same busStop is in a line
 def addBusStop(fromNodeId, toNodeId, link, start, repeatNumber, catalog, model):
+    """
+    Function to create the bus stop objects in the Aimsun network
+    repeatNumber is the number of times that same busStop is in a line
+    """
     # Check if the stop already exists
     busStopType = model.getType("GKBusStop")
     if start is True:
@@ -223,8 +175,11 @@ def addBusStop(fromNodeId, toNodeId, link, start, repeatNumber, catalog, model):
     # TODO add a parameter to set the stop length and position
     return busStop
 
-# Function to build the transit lines Aimsun
+
 def addTransitLine(lineId, lineName, pathLinks, busStops, transitVehicle, allVehicles, roadTypes, layer, catalog, model):
+    """
+    Function to build the transit lines Aimsun
+    """
     cmd = model.createNewCmd( model.getType( "GKPublicLine" ) )
     cmd.setModel( model )
     model.getCommander().addCommand( cmd )
@@ -261,9 +216,11 @@ def addTransitLine(lineId, lineName, pathLinks, busStops, transitVehicle, allVeh
     if check[0] is False:
         print (f"Issue importing transit line {lineId} {lineName}")
 
-# Takes a path list as argument
-# Returns the nodes and links that make up the path
 def getPath(pathList, nodeConnections, catalog, model):
+    """
+    Takes a path list as argument
+    Returns the nodes and links that make up the path
+    """
     nodes = []
     links = []
     nodeType = model.getType("GKNode")
@@ -288,12 +245,14 @@ def getPath(pathList, nodeConnections, catalog, model):
         links.append(link)
     return nodes, links
 
-# Function to create the transit lines from reading the file to adding to the network
 def importTransit(networkZipFileObject, fileName, roadTypes, layer, nodeConnections, catalog, model):
+    """
+    Function to create the transit lines from reading the file to adding to the network
+    """
     # read the transit file
     print("Import transit network")
     print("Read transit file")
-    nodes, stops, lines = readTransitFile(networkZipFileObject, fileName)
+    nodes, stops, lines = common.readTransitFile(networkZipFileObject, fileName)
     # Cache the vehicle types
     allVehicles=[]
     sectionType = model.getType("GKVehicle")
@@ -370,7 +329,6 @@ def run_xtmf(parameters, model, console):
     """
     networkPackage = parameters["NetworkPackageFile"]
     _execute(networkPackage, model, console)
-
 
 def _execute(networkPackage, inputModel, console):
     """ 

--- a/src/TMGToolbox/inputOutput/importTransitNetwork.py
+++ b/src/TMGToolbox/inputOutput/importTransitNetwork.py
@@ -252,7 +252,7 @@ def importTransit(networkZipFileObject, fileName, roadTypes, layer, nodeConnecti
     # read the transit file
     print("Import transit network")
     print("Read transit file")
-    nodes, stops, lines = common.readTransitFile(networkZipFileObject, fileName)
+    nodes, stops, lines = common.getTransitNodesStopsAndLinesFromNWP(networkZipFileObject)
     # Cache the vehicle types
     allVehicles=[]
     sectionType = model.getType("GKVehicle")

--- a/src/TMGToolbox/inputOutput/importTransitSchedule.py
+++ b/src/TMGToolbox/inputOutput/importTransitSchedule.py
@@ -35,10 +35,10 @@ def readServiceTables(fileLocation, header=True):
         serviceTables.append((transitLine, departures, arrivals))
     return serviceTables
 
-def buildTransitVehDict(networkZipFileObject, filename, model):
+def buildTransitVehDict(networkZipFileObject, model):
     transitVehDict = dict()
     vehType = model.getType("GKVehicle")
-    node, stops, lines = common.readTransitFile(networkZipFileObject, filename)
+    node, stops, lines = common.getTransitNodesStopsAndLinesFromNWP(networkZipFileObject)
     for i in range(len(lines)):
         lineId = lines[i][0]
         lineVehicle = model.getCatalog().findObjectByExternalId(f"transitVeh_{lines[i][2]}", vehType)
@@ -130,7 +130,7 @@ def _execute(model, console, parameters):
     networkZipFileObject = common.extract_network_packagefile(networkPackage)
     
     # get the transitfile
-    transitVehDict = buildTransitVehDict(networkZipFileObject, "transit.221", model)
+    transitVehDict = buildTransitVehDict(networkZipFileObject, model)
     
     serviceTables = readServiceTables(parameters["ServiceTableCSV"])
     for serviceTable in serviceTables:

--- a/test/TMG.Aimsun.Tests/TestModuleImportTransitSchedule.cs
+++ b/test/TMG.Aimsun.Tests/TestModuleImportTransitSchedule.cs
@@ -35,9 +35,8 @@ namespace TMG.Aimsun.Tests
             string modulePath = Path.Combine(Helper.TestConfiguration.ModulePath, "inputOutput\\importTransitSchedule.py");
             string jsonParameters = JsonConvert.SerializeObject(new
             {
-                ModelDirectory = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\Frabitztown"),
-                ServiceTableCSV = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\frab_service_table.csv"),
-                TransitFile = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\Frabitztown\\transit.221 ")
+                NetworkPackageFile = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\Frabitztown.nwp"),
+                ServiceTableCSV = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\frab_service_table.csv")
             });
             Helper.Modeller.Run(null, modulePath, jsonParameters);
         }
@@ -51,9 +50,8 @@ namespace TMG.Aimsun.Tests
             string modulePath = Path.Combine(Helper.TestConfiguration.ModulePath, "inputOutput\\importTransitSchedule.py");
             string jsonParameters = JsonConvert.SerializeObject(new
             {
-                ModelDirectory = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\Frabitztown"),
-                ServiceTableCSV = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\frab_service_table.csv"),
-                TransitFile = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\Frabitztown\\transit.221 ")
+                NetworkPackageFile = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\Frabitztown.nwp"),
+                ServiceTableCSV = Path.Combine(Helper.TestConfiguration.NetworkFolder, "inputFiles\\frab_service_table.csv")
             });
             Helper.Modeller.Run(null, modulePath, jsonParameters);
 


### PR DESCRIPTION
ImportTransitSchedule now uses nwp package
moved readTransitFile to common module since its being used by another tool
cleaned up documentation strings moved them insdie the function